### PR TITLE
Percent encoding payload

### DIFF
--- a/Service.gs
+++ b/Service.gs
@@ -394,6 +394,18 @@ Service_.prototype.fetchInternal_ = function(url, params, opt_token,
     default:
       throw 'Unknown param location: ' + this.paramLocation_;
   }
+
+  var formDataString = function(obj) {
+    var formData = [];
+    var e = signer.percentEncode;
+    for (var key in obj) {
+      formData.push(e(key) + '=' + e(obj[key]));
+    }
+    return formData.join('&');
+  }
+  
+  params.payload = formDataString(params.payload);
+
   return UrlFetchApp.fetch(url, params);
 };
 


### PR DESCRIPTION
UrlFetchApp.fetch(url, params) does not encode params.payload properly.
So, Twitter's POST statuses/update API (https://api.twitter.com/1.1/statuses/update.json) always fail with error response {"errors":[{"message":"Could not authenticate you","code":32}]} .