### PR TITLE
Fix signing for URL query parameters with '='

### DIFF
--- a/Signer.gs
+++ b/Signer.gs
@@ -186,21 +186,21 @@
     return url.split('?')[0];
   };
 
- /**
- * Get data from String
- * @param  {String} string
- * @return {Object}
- */
-OAuth.prototype.deParam = function(string) {
+  /**
+  * Get data from String
+  * @param  {String} string
+  * @return {Object}
+  */
+  OAuth.prototype.deParam = function(string) {
     var arr = string.split('&');
     var data = {};
 
     for(var i = 0; i < arr.length; i++) {
-        var item = arr[i].split('=');
-        data[item[0]] = decodeURIComponent(item[1]);
+      var item = arr[i].split('=');
+      data[item[0]] = decodeURIComponent(item[1]);
     }
     return data;
-};
+  };
 
   /**
   * Get data from url

--- a/Signer.gs
+++ b/Signer.gs
@@ -196,8 +196,11 @@
     var data = {};
 
     for(var i = 0; i < arr.length; i++) {
-      var item = arr[i].split('=');
-      data[item[0]] = item[1];
+      var parts = arr[i].split('=');
+      var key = parts[0];
+      var value = parts.slice(1).join('=');
+
+      data[key] = value;
     }
     return data;
   };

--- a/Signer.gs
+++ b/Signer.gs
@@ -186,24 +186,21 @@
     return url.split('?')[0];
   };
 
-  /**
-  * Get data from String
-  * @param  {String} string
-  * @return {Object}
-  */
-  OAuth.prototype.deParam = function(string) {
-    var arr = decodeURIComponent(string).split('&');
+ /**
+ * Get data from String
+ * @param  {String} string
+ * @return {Object}
+ */
+OAuth.prototype.deParam = function(string) {
+    var arr = string.split('&');
     var data = {};
 
     for(var i = 0; i < arr.length; i++) {
-      var parts = arr[i].split('=');
-      var key = parts[0];
-      var value = parts.slice(1).join('=');
-
-      data[key] = value;
+        var item = arr[i].split('=');
+        data[item[0]] = decodeURIComponent(item[1]);
     }
     return data;
-  };
+};
 
   /**
   * Get data from url


### PR DESCRIPTION
When a URL query parameter contains `=` (%3D), `deParam()` drops everything after the second `=`.

This change preserves all of the contents after the first `=` (including additional `=`).